### PR TITLE
Limit index request by default to the last 90 days

### DIFF
--- a/app/controllers/ticket_dispenser/tickets_controller.rb
+++ b/app/controllers/ticket_dispenser/tickets_controller.rb
@@ -3,7 +3,14 @@
 module TicketDispenser
   class TicketsController < ApplicationController
     def index
-      render json: Ticket.all.includes(:project, :owner, messages: :sender), status: :ok
+      query = Ticket.all.includes(:project, :owner, messages: :sender).order(:id)
+
+      created_after_date = ticket_params[:created_after] || 90.days.ago
+      created_before_date = ticket_params[:created_before] || 1.day.from_now
+      query = query.where('created_at <= DATE(?) AND created_at > DATE(?)',
+                          created_before_date, created_after_date)
+
+      render json: query, status: :ok
     end
 
     def show
@@ -44,7 +51,8 @@ module TicketDispenser
     end
 
     def ticket_params
-      params.permit(:id, :status, :project, :alert, :user, :ticket_id, :owner_id)
+      params.permit(:id, :status, :project, :alert, :user, :ticket_id, :owner_id,
+                    :created_after, :created_before, :limit, :offset)
     end
   end
 end

--- a/spec/controllers/ticket_dispenser/tickets_controller_spec.rb
+++ b/spec/controllers/ticket_dispenser/tickets_controller_spec.rb
@@ -31,6 +31,15 @@ describe TicketDispenser::TicketsController, type: :request do
       expect(message['sender']['username']).to eq(user.username)
       expect(message['read']).to equal(false)
     end
+
+    it 'should not include tickets created more than 90 days ago by default' do
+      ticket = TicketDispenser::Ticket.create(owner: admin, project: course, status: 0, created_at: 120.days.ago)
+      TicketDispenser::Message.create(ticket: ticket, sender: user, content: 'Hello')
+
+      get '/tickets'
+      tickets = JSON.parse(response.body)
+      expect(tickets.length).to equal(0)
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
This sets up a limit for how many days back to request a ticket and allows for optional query parameters to set the range.